### PR TITLE
Remove Flat from example scripts

### DIFF
--- a/resources/plutus-sources/plutus-example/src/Cardano/PlutusExample/LockingScript.hs
+++ b/resources/plutus-sources/plutus-example/src/Cardano/PlutusExample/LockingScript.hs
@@ -16,8 +16,9 @@ import           Prelude hiding (($))
 
 import           Cardano.Api.Shelley (PlutusScript (..), PlutusScriptV1)
 
+import           Codec.Serialise
 import qualified Data.ByteString.Short as SBS
-import qualified Flat
+import qualified Data.ByteString.Lazy  as LBS
 
 import qualified Plutus.V1.Ledger.Scripts as Plutus
 import           PlutusTx (Data (..))
@@ -35,7 +36,7 @@ script :: Plutus.Script
 script = Plutus.unValidatorScript validator
 
 untypedLockingScriptAsShortBs :: SBS.ShortByteString
-untypedLockingScriptAsShortBs =  SBS.toShort $ Flat.flat script
+untypedLockingScriptAsShortBs =  SBS.toShort . LBS.toStrict $ serialise script
 
 apiExampleUntypedPlutusLockingScript :: PlutusScript PlutusScriptV1
 apiExampleUntypedPlutusLockingScript = PlutusScriptSerialised untypedLockingScriptAsShortBs

--- a/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorld.hs
+++ b/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorld.hs
@@ -16,8 +16,9 @@ import           Prelude hiding (($))
 
 import           Cardano.Api.Shelley (PlutusScript (..), PlutusScriptV1)
 
+import           Codec.Serialise
 import qualified Data.ByteString.Short as SBS
-import qualified Flat
+import qualified Data.ByteString.Lazy  as LBS
 
 import qualified Plutus.V1.Ledger.Scripts as Plutus
 import           PlutusTx (Data (..))
@@ -60,7 +61,7 @@ helloWorldScript = Plutus.unValidatorScript helloWorldValidator
 -}
 
 helloWorldSBS :: SBS.ShortByteString
-helloWorldSBS =  SBS.toShort $ Flat.flat helloWorldScript
+helloWorldSBS =  SBS.toShort . LBS.toStrict $ serialise helloWorldScript
 
 {-
     As a Serialised Script


### PR DESCRIPTION
Remove use of Flat from example scripts because produced serialised script doesn't work onchain.