### PR TITLE
Split helloworld -> numeric and bytestring version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+**/dist-newstyle/
 Alonzo-exercises/.DS_Store

--- a/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-bytestring.hs
+++ b/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-bytestring.hs
@@ -5,12 +5,11 @@ import           System.Environment
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Plutus.V1.Ledger.Api as Plutus
 
 import qualified Data.ByteString.Short as SBS
 
-import           Cardano.PlutusExample.HelloWorld (helloWorldSBS, helloWorldSerialised)
+import           Cardano.PlutusExample.HelloWorldByteString (helloWorldSBS, helloWorldSerialised)
 
 main :: IO ()
 main = do
@@ -28,7 +27,7 @@ writePlutusScript scriptnum filename scriptSerial scriptSBS =
   do
   case Plutus.defaultCostModelParams of
         Just m ->
-          let Alonzo.Data pData = toAlonzoData (ScriptDataNumber scriptnum)
+          let pData = toPlutusData (ScriptDataNumber scriptnum)
               (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS [pData]
           in do print ("Log output" :: String) >> print logout
                 case e of

--- a/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-numeric.hs
+++ b/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-numeric.hs
@@ -1,0 +1,40 @@
+
+import           Prelude
+import           System.Environment
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import qualified Plutus.V1.Ledger.Api as Plutus
+
+import qualified Data.ByteString.Short as SBS
+
+import           Cardano.PlutusExample.HelloWorldNumeric (helloWorldSBS, helloWorldSerialised)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let nargs = length args
+  let scriptnum = if nargs > 0 then read (args!!0) else 42
+  let scriptname = if nargs > 1 then args!!1 else  "result.plutus"
+  putStrLn $ "Writing output to: " ++ scriptname
+  writePlutusScript scriptnum scriptname helloWorldSerialised helloWorldSBS
+
+
+
+writePlutusScript :: Integer -> FilePath -> PlutusScript PlutusScriptV1 -> SBS.ShortByteString -> IO ()
+writePlutusScript scriptnum filename scriptSerial scriptSBS =
+  do
+  case Plutus.defaultCostModelParams of
+        Just m ->
+          let pData = toPlutusData (ScriptDataNumber scriptnum)
+              (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS [pData]
+          in do print ("Log output" :: String) >> print logout
+                case e of
+                  Left evalErr -> print ("Eval Error" :: String) >> print evalErr
+                  Right exbudget -> print ("Ex Budget" :: String) >> print exbudget
+        Nothing -> error "defaultCostModelParams failed"
+  result <- writeFileTextEnvelope filename Nothing scriptSerial
+  case result of
+    Left err -> print $ displayError err
+    Right () -> return ()

--- a/resources/plutus-sources/plutus-helloworld/plutus-helloworld.cabal
+++ b/resources/plutus-sources/plutus-helloworld/plutus-helloworld.cabal
@@ -6,8 +6,8 @@ description:            End to end examples of creating and executing Plutus scr
 author:                 IOHK
 maintainer:             operations@iohk.io
 license:                Apache-2.0
-license-files:          LICENSE
-                        NOTICE
+-- license-files:          LICENSE
+                        -- NOTICE
 build-type:             Simple
 extra-source-files:     README.md
 
@@ -45,11 +45,12 @@ library
 
   hs-source-dirs:       src
 
-  exposed-modules:      Cardano.PlutusExample.HelloWorld
+  exposed-modules:      Cardano.PlutusExample.HelloWorldByteString
+                      , Cardano.PlutusExample.HelloWorldNumeric
 
   build-depends:        bytestring
                       , cardano-api
-                      , flat
+                      -- , flat
                       , plutus-core
                       , plutus-ledger
                       , plutus-ledger-api
@@ -57,17 +58,27 @@ library
                       , plutus-tx-plugin
                       , serialise
 
-executable plutus-helloworld
+executable plutus-helloworld-bytestring
   import:               base, project-config
   hs-source-dirs:       app
-  main-is:              plutus-helloworld.hs
+  main-is:              plutus-helloworld-bytestring.hs
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
   build-depends:        cardano-api
-                      , cardano-ledger-alonzo
+                      -- , cardano-ledger-alonzo
                       , plutus-helloworld
                       , plutus-ledger-api
                       , bytestring
 
+executable plutus-helloworld-numeric
+  import:               base, project-config
+  hs-source-dirs:       app
+  main-is:              plutus-helloworld-numeric.hs
+  ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
+  build-depends:        cardano-api
+                      -- , cardano-ledger-alonzo
+                      , plutus-helloworld
+                      , plutus-ledger-api
+                      , bytestring
 

--- a/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldByteString.hs
+++ b/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldByteString.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.PlutusExample.HelloWorldByteString
+  ( helloWorldSerialised
+  , helloWorldSBS
+  ) where
+
+import           Prelude hiding (($))
+
+import           Cardano.Api.Shelley (PlutusScript (..), PlutusScriptV1)
+
+import           Codec.Serialise
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Lazy  as LBS
+
+import           Ledger               hiding (singleton)
+import qualified Ledger.Typed.Scripts as Scripts
+import qualified PlutusTx
+import           PlutusTx.Prelude as P hiding (Semigroup (..), unless)
+
+
+{-
+  The "hello world" message as a bytestring
+-}
+
+hello :: P.ByteString
+hello = "Hello World!"
+
+{-
+   The Hello World validator script
+-}
+
+{-# INLINABLE helloWorld #-}
+
+helloWorld :: P.ByteString -> P.ByteString -> P.ByteString -> ScriptContext -> P.Bool
+helloWorld keyword datum _ _ = keyword P.== datum
+
+{-
+    As a ScriptInstance
+-}
+
+data HelloWorld
+instance Scripts.ScriptType HelloWorld where
+    type instance DatumType HelloWorld = P.ByteString
+    type instance RedeemerType HelloWorld = P.ByteString
+
+helloWorldInstance :: Scripts.ScriptInstance HelloWorld
+helloWorldInstance = Scripts.validator @HelloWorld
+    ($$(PlutusTx.compile [|| helloWorld ||]) `PlutusTx.applyCode` PlutusTx.liftCode hello)
+    $$(PlutusTx.compile [|| wrap ||])
+  where
+    wrap = Scripts.wrapValidator @P.ByteString @P.ByteString
+
+{-
+    As a Validator
+-}
+
+helloWorldValidator :: Validator
+helloWorldValidator = Scripts.validatorScript helloWorldInstance
+
+
+{-
+    As a Script
+-}
+
+helloWorldScript :: Script
+helloWorldScript = unValidatorScript helloWorldValidator
+
+{-
+    As a Short Byte String
+-}
+
+helloWorldSBS :: SBS.ShortByteString
+helloWorldSBS =  SBS.toShort . LBS.toStrict $ serialise helloWorldScript
+
+{-
+    As a Serialised Script
+-}
+
+helloWorldSerialised :: PlutusScript PlutusScriptV1
+helloWorldSerialised = PlutusScriptSerialised helloWorldSBS
+

--- a/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldNumeric.hs
+++ b/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldNumeric.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Cardano.PlutusExample.HelloWorld
+module Cardano.PlutusExample.HelloWorldNumeric
   ( helloWorldSerialised
   , helloWorldSBS
   ) where
@@ -27,13 +27,11 @@ import           PlutusTx.Prelude as P hiding (Semigroup (..), unless)
 
 
 {-
-  The "hello world" message as a data item - converted to
-  an Integer and shortened to fit within the 8-byte limit
-  for an "int" datum.
+  The "hello world" message as a data item
 -}
 
 hello :: Data
-hello = I 0x48656c6c6f21
+hello = I 123
 
 {-
    The Hello World validator script
@@ -42,7 +40,7 @@ hello = I 0x48656c6c6f21
 {-# INLINABLE helloWorld #-}
 
 helloWorld :: Data -> Data -> Data -> ()
-helloWorld datum redeemer _ = if datum P.== hello then () else (P.error ())
+helloWorld datum _ _ = if datum P.== hello then () else (P.error ())
 
 {-
     As a Validator


### PR DESCRIPTION
The new executable `plutus-helloworld-bytestring` succeeds in doing what
the previous `plutus-helloworld` attempted but (apparently) failed to
do: implement a validator that would only accept the bytestring datum
"Hello World!".

It does this by using a parametric typed validator with an extra argument
`keyword` to which the datum is compared. During compilation of the
validator, the bytestring keyword "Hello World!" injected via
`applyCode` and `liftCode`.

Another new executable `plutus-helloworld-numeric` simplifies the
validator significantly by making the keyword numeric (123), which
avoids the need for a parametric typed validator. This is possible
because integer values of the Plutus `Data` type can be constructed
directly, unlike bytestring values of this type (I think).