### PR TITLE
[#20] Fix location of Alonzo White configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The exercises are designed to help those who are unfamiliar with the Cardano nod
 ### Network Configurations
 
 
-[Alonzo White configuration files](https://github.com/input-output-hk/iohk-nix/pull/483)
+[Alonzo White configuration files](https://hydra.iohk.io/build/6854041/download/1/index.html)
 
 ## Exercise 1: Getting Started
 


### PR DESCRIPTION
Currently the link in the main README points to a PR.

Following that to Hydra, I ended up with https://hydra.iohk.io/build/6854041/download/1/index.html
Is that the set of configs we should be using?