### PR TITLE
Added description+link for general-purpose oracle.

### DIFF
--- a/resources/community-contributions/README.md
+++ b/resources/community-contributions/README.md
@@ -1,2 +1,7 @@
 # Community Contributions
-This area is provided for community contributions
+
+This area is provided for community contributions.
+
+
+*   [A general purpose oracle for JSON data](https://github.com/functionally/mantis-oracle/blob/main/ReadMe.md): This Plutus oracle reports structured data (namely, the `PlutuxTx.BuiltinData` type, which encompasses any JSON data that can be serialized as CBOR) to a transaction if the fee, as a quantity of a fungible token and/or ADA, is paid. It can be incorporated into other smart-contracts that use the oracle's value in their validation logic. A command-line tool for creating, writing, and deleting the oracle is provided, as is an extended example of the Oracle's use. The oracle also supports the Plutus Application Backend (PAB) and simulation. The diagram below shows a simple use case involving creating, reading, and writing the oracle.
+<img alt="Example usage of the JSON oracle." src="https://raw.githubusercontent.com/functionally/mantis-oracle/main/transactions.png" width="600" align="right"/>


### PR DESCRIPTION
@kevinhammond suggested on Discord that I create a pull request to add this description and link to the general-purpose oracle that I have running on `alonzo purple`. The code is documented and contains a command-line interface and support for a slightly old version of the PAB and simulator. A detailed, step-by-step example is provided. The code is actively maintained and will be upgraded to the latest releases of the Cardano node and PAB as those become available.