### PR TITLE
Add untyped helloworld-bytestring-literal script example

### DIFF
--- a/resources/plutus-sources/plutus-helloworld/README.md
+++ b/resources/plutus-sources/plutus-helloworld/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a simple "Hello World" script.  There are two versions: one using an integer literal (needed because the Plutus interpreter doesn't currently accept byte string literals) and a slighly more complicated one using a bytestring parameter.
 
-``plutus-helloworld'' -- very simple numeric version
+``plutus-helloworld`` -- very simple numeric version
 
-``plutus-helloworld-bytestring'' -- more compex version using bytestring constant
+``plutus-helloworld-bytestring`` -- more compex typed version using a paramaterised validator and bytestring constant
+
+``plutus-helloworld-literal-bytestring`` -- an untyped example using literal builtin bytestring (significantly smaller when serialised than typed validator)

--- a/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-literal-bytestring.hs
+++ b/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-literal-bytestring.hs
@@ -1,0 +1,39 @@
+
+import           Prelude
+import           System.Environment
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import qualified Cardano.Ledger.Alonzo.Data as Alonzo
+import qualified Plutus.V1.Ledger.Api as Plutus
+
+import qualified Data.ByteString.Short as SBS
+
+import           Cardano.PlutusExample.HelloWorldLiteralByteString (helloWorldSBS, helloWorldSerialised)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let nargs = length args
+  let scriptnum = if nargs > 0 then read (args!!0) else 42
+  let scriptname = if nargs > 1 then args!!1 else  "result.plutus"
+  putStrLn $ "Writing output to: " ++ scriptname
+  writePlutusScript scriptnum scriptname helloWorldSerialised helloWorldSBS
+
+writePlutusScript :: Integer -> FilePath -> PlutusScript PlutusScriptV1 -> SBS.ShortByteString -> IO ()
+writePlutusScript scriptnum filename scriptSerial scriptSBS =
+  do
+  case Plutus.defaultCostModelParams of
+        Just m ->
+          let Alonzo.Data pData = toAlonzoData (ScriptDataNumber scriptnum)
+              (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS [pData]
+          in do print ("Log output" :: String) >> print logout
+                case e of
+                  Left evalErr -> print ("Eval Error" :: String) >> print evalErr
+                  Right exbudget -> print ("Ex Budget" :: String) >> print exbudget
+        Nothing -> error "defaultCostModelParams failed"
+  result <- writeFileTextEnvelope filename Nothing scriptSerial
+  case result of
+    Left err -> print $ displayError err
+    Right () -> return ()

--- a/resources/plutus-sources/plutus-helloworld/plutus-helloworld.cabal
+++ b/resources/plutus-sources/plutus-helloworld/plutus-helloworld.cabal
@@ -46,6 +46,7 @@ library
 
   exposed-modules:      Cardano.PlutusExample.HelloWorld
                       , Cardano.PlutusExample.HelloWorldByteStringParametric
+                      , Cardano.PlutusExample.HelloWorldLiteralByteString
 
   build-depends:        bytestring
                       , cardano-api
@@ -75,6 +76,20 @@ executable plutus-helloworld-bytestring
   import:               base, project-config
   hs-source-dirs:       app
   main-is:              plutus-helloworld-bytestring.hs
+  ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
+
+  build-depends:        aeson
+                      , cardano-api
+                      , cardano-ledger-alonzo
+                      , plutus-helloworld
+                      , plutus-ledger-api
+                      , plutus-tx
+                      , bytestring
+
+executable plutus-helloworld-literal-bytestring
+  import:               base, project-config
+  hs-source-dirs:       app
+  main-is:              plutus-helloworld-literal-bytestring.hs
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
   build-depends:        aeson

--- a/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldLiteralByteString.hs
+++ b/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldLiteralByteString.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.PlutusExample.HelloWorldLiteralByteString
+  ( helloWorldSerialised
+  , helloWorldSBS
+  ) where
+
+import           Prelude hiding (($))
+
+import           Cardano.Api.Shelley (PlutusScript (..), PlutusScriptV1)
+
+import           Codec.Serialise
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Lazy  as LBS
+
+import qualified Plutus.V1.Ledger.Scripts as Plutus
+import qualified PlutusTx
+import qualified PlutusTx.Builtins as BI
+import           PlutusTx.Prelude as P hiding (Semigroup (..), unless)
+
+
+hello :: BuiltinData
+hello = BI.mkB "Hello World!"
+
+{-
+   The Hello World validator script
+-}
+
+{-# INLINABLE helloWorld #-}
+
+helloWorld :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+helloWorld datum redeemer context = if datum P.== hello then () else (P.error ())
+
+{-
+    As a Validator
+-}
+
+helloWorldValidator :: Plutus.Validator
+helloWorldValidator = Plutus.mkValidatorScript $$(PlutusTx.compile [|| helloWorld ||])
+
+{-
+    As a Script
+-}
+
+helloWorldScript :: Plutus.Script
+helloWorldScript = Plutus.unValidatorScript helloWorldValidator
+
+{-
+    As a Short Byte String
+-}
+
+helloWorldSBS :: SBS.ShortByteString
+helloWorldSBS =  SBS.toShort . LBS.toStrict $ serialise helloWorldScript
+
+{-
+    As a Serialised Script
+-}
+
+helloWorldSerialised :: PlutusScript PlutusScriptV1
+helloWorldSerialised = PlutusScriptSerialised helloWorldSBS
+


### PR DESCRIPTION
Add a new untyped helloworld example that uses bytestring literal of "Hello World!". This is much smaller than the typed parameterised example when serialised.