### PR TITLE
Fix wrong skey signing - MissingVKeyWitnessesUTXOW

### DIFF
--- a/Alonzo-tutorials/Plutus_transactions_tutorial.md
+++ b/Alonzo-tutorials/Plutus_transactions_tutorial.md
@@ -79,7 +79,7 @@ Once Nix is installed, log out and then log back in, so it is activated properly
 
   
 ```
-$ git clone [https://github.com/input-output-hk/cardano-node](https://github.com/input-output-hk/cardano-node)
+$ git clone https://github.com/input-output-hk/cardano-node
 $ cd cardano-node
 $ git checkout -b alonzo-purple tags/alonzo-purple-1.0.2
 ```
@@ -573,7 +573,7 @@ If we use a UTXO that is part of a script address as an input of the transaction
 ```
 [nix-shell:~/..]$ cardano-cli transaction sign \
 --tx-body-file test-alonzo.tx \
---signing-key-file payment.skey \
+--signing-key-file payment2.skey \
 --testnet-magic ${TESTNET_MAGIC} \
 --out-file test-alonzo.signed
 ```


### PR DESCRIPTION
Fix wrong skey signing - MissingVKeyWitnessesUTXOW

when using `payment.skey`  to sign the tnx then submit
```
$ cardano-cli transaction sign \                                                             
--tx-body-file test-alonzo.tx \
--signing-key-file payment.skey \
--testnet-magic ${TESTNET_MAGIC} \
--out-file test-alonzo.signed

$ cardano-cli transaction submit --testnet-magic ${TESTNET_MAGIC} --tx-file test-alonzo.signed

>> Command failed: transaction submit  Error: Error while submitting tx: ShelleyTxValidationError ShelleyBasedEraAlonzo (ApplyTxError [UtxowFailure (WrappedShelleyEraFailure (MissingVKeyWitnessesUTXOW (WitHashes (fromList [KeyHash "bbaad638148332b0926565c3914535ebcaa719ecb41756cc79ff811c"]))))])
```

The correct skey is `payment2.skey`  which is relavent to `--tx-in-collateral ${txCollateral}`
[Plutus_transactions_tutorial.md?plain=1#L532-L560](https://github.com/input-output-hk/Alonzo-testnet/blob/main/Alonzo-tutorials/Plutus_transactions_tutorial.md?plain=1#L532-L560)

```
cardano-cli transaction sign \
--tx-body-file test-alonzo.tx \
--signing-key-file payment2.skey \
--testnet-magic ${TESTNET_MAGIC} \
--out-file test-alonzo.signed
```