### PR TITLE
Fixing error when running `plutus-helloworld-literal-bytestring` with args

### DIFF
--- a/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-literal-bytestring.hs
+++ b/resources/plutus-sources/plutus-helloworld/app/plutus-helloworld-literal-bytestring.hs
@@ -14,21 +14,22 @@ main :: IO ()
 main = do
   args <- getArgs
   let nargs = length args
-  let scriptData = if nargs > 0 then fromString (args!!0) else "Hello World!"
+  let scriptData = if nargs > 0 then head args else "Hello World!"
   let scriptname = if nargs > 1 then args!!1 else  "result.plutus"
-  putStrLn $ "Writing output to: " ++ scriptname
-  writePlutusScript scriptData scriptname helloWorldSerialised helloWorldSBS
+  putStrLn $ "Writing output to: " ++ scriptname ++ " with scriptData " ++ scriptData
+  writePlutusScript (fromString scriptData) scriptname helloWorldSerialised helloWorldSBS
 
 writePlutusScript :: Plutus.BuiltinByteString -> FilePath -> PlutusScript PlutusScriptV1 -> SBS.ShortByteString -> IO ()
 writePlutusScript scriptData filename scriptSerial scriptSBS =
   do
   case Plutus.defaultCostModelParams of
         Just m ->
-          let (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS
-                              [ Plutus.toData scriptData
-                              , Plutus.toData ()
-                              , Plutus.toData ()
-                              ]
+          let (logout, e) =
+                Plutus.evaluateScriptCounting
+                    Plutus.Verbose
+                    m
+                    scriptSBS
+                    [Plutus.toData scriptData]
           in do print ("Log output" :: String) >> print logout
                 case e of
                   Left evalErr -> print ("Eval Error" :: String) >> print evalErr


### PR DESCRIPTION
When running `plutus-helloworld-literal-bytestring` with args
```
cabal run plutus-helloworld-literal-bytestring -- "Xin chào!" helloworld.plutus
```

The log
```
Up to date
Writing output to: helloworld.plutus
"Log output"
[]
"Eval Error"
CekError An error has occurred:  User error:
The provided Plutus code called 'error'.
```
We only pass `Datum` to the validator script
https://github.com/input-output-hk/Alonzo-testnet/blob/main/resources/plutus-sources/plutus-helloworld/src/Cardano/PlutusExample/HelloWorldLiteralByteString.hs#L38-L39
```
helloWorld :: BuiltinData -> BuiltinData -> BuiltinData -> ()
helloWorld datum _redeemer _context = if datum P.== hello then () else (P.error ())
```
so, just need to pass 1 into Data list
![Screenshot from 2021-10-29 15-35-43](https://user-images.githubusercontent.com/81793148/139403707-60283aa8-811f-4076-aab4-22d6029be2cc.png)

```
Plutus.evaluateScriptCounting
                    Plutus.Verbose
                    m
                    scriptSBS
                    [Plutus.toData scriptData]
```